### PR TITLE
fix: set data to undefined in queryBuilder for GET requests

### DIFF
--- a/src/drivers/default/builders/queryBuilder.ts
+++ b/src/drivers/default/builders/queryBuilder.ts
@@ -54,7 +54,8 @@ export class QueryBuilder<M extends Model,
 		const response = await this.httpClient.request(
 			'/',
 			HttpMethod.GET,
-			this.prepareQueryParams({limit, page})
+			this.prepareQueryParams({limit, page}),
+			undefined
 		);
 
 		return response.data.data.map((attributes: AllAttributes & Relations) => {
@@ -84,7 +85,8 @@ export class QueryBuilder<M extends Model,
 		const response = await this.httpClient.request(
 			`/${key}`,
 			HttpMethod.GET,
-			this.prepareQueryParams()
+			this.prepareQueryParams(),
+			undefined
 		);
 
 		return this.hydrate(response.data.data, response);


### PR DESCRIPTION
This pull request, should solve the problem that I've reported in the issue https://github.com/tailflow/laravel-orion-ts/issues/2 .

Setting data to `undefined`, gives axios a proper request, and does not throw a Network Error.