### PR TITLE
BREAKING! Hybrid build to CommonJS and ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 		"sdk"
 	],
 	"files": [
-		"lib"
+		"dist"
 	],
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
 	"author": "Aleksei Zarubin alex@zarubin.co",
 	"repository": {
 		"type": "git",
@@ -19,8 +21,10 @@
 	},
 	"license": "MIT",
 	"scripts": {
-		"prebuild": "rimraf lib",
-		"build": "tsc",
+		"prebuild": "rimraf lib && rimraf dist",
+		"build": "npm run build:cjs && npm run build:esm",
+		"build:cjs": "tsc -p tsconfig-cjs.json",
+		"build:esm": "tsc",
 		"dev": "tsc -w",
 		"test": "jest",
 		"lint": "eslint . --ext .ts"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './model';
+export * from './orion';

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+      "module": "commonjs",
+      "outDir": "dist/cjs",
+      "target": "es2015"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true,
 		"esModuleInterop": true,
-		"outDir": "lib",
+		"outDir": "dist/esm",
 		"typeRoots": [
 			"node_modules/@types"
 		]


### PR DESCRIPTION
Closes #6 

# Current Problem
Currently, this package doesn't expose a module. It just specifies `files` key with `lib` folder.
This is why `laravel-orion-ts` couldn't be used in Next.js applications.

# Solution
* This PR changes `build` script to build separately two versions: CommonJS (under `./dist/cjs`) and ES Modules (under `./dist/esm`). It's necessary because in most cases plain ES Modules aren't transpiled and couldn't be used (at least in Next.js apps right now)
* Added `index` file as entry point for our module, which currently exposes common entities.
* It's also two new keys in `package.json` for both module types.

# Why breaking change
It could break up things, and it will be better to ship new major version.

In most cases this import would work:
```js
import { Orion } from '@tailflow/laravel-orion';
```
Import as CommonJS module:
```js
import { Orion } from '@tailflow/laravel-orion/dist/cjs';
```
or as ES module:
```js
import { Orion } from '@tailflow/laravel-orion/dist/esm';
```

I leave this PR in Draft while discussion isn't finished.

## Possible points to discuss
* file structure - for example remove `dist` directory at all and build files to `<package-root>/cjs` and `<package-root>/esm` or whatever